### PR TITLE
[v3] Add level one headings to Markdown files

### DIFF
--- a/concepts/arrays/about.md
+++ b/concepts/arrays/about.md
@@ -1,3 +1,5 @@
+# About
+
 An [`array`][arrays] in F# is a mutable collection of zero or more values with a fixed length. This means that once an array has been created, its size cannot change, but its values can. The values in an array must all have the same type. [Arrays can be defined as follows][creating-arrays]:
 
 ```fsharp

--- a/concepts/arrays/introduction.md
+++ b/concepts/arrays/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 An `array` in F# is a mutable collection of zero or more values with a fixed length. This means that once an array has been created, its size cannot change, but its values can. The values in an array must all have the same type. Arrays can be defined as follows:
 
 ```fsharp

--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -1,3 +1,5 @@
+# About
+
 In F#, everything that has a type and can be defined is known as a _value_. That includes booleans, integers and lists, but also functions. Integer values are defined as one or more (consecutive) digits and support the [default mathematical operators][operators].
 
 Assigning a value to a name is referred to as a _binding_. [Bindings][bindings] are immutable, which makes them similar to constants in other languages. Bindings are defined using the `let` keyword.

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In F#, assigning a value to a name is referred to as a _binding_. Bindings are immutable, which makes them similar to constants in other languages. As F# is a statically-typed language, each binding has a type at compile-time.
 
 Bindings are defined using the `let` keyword. Specifying a binding's type is optional for most bindings, as F#'s _type inference_ can usually infer the type based on their value. A binding looks like this:

--- a/concepts/booleans/about.md
+++ b/concepts/booleans/about.md
@@ -1,3 +1,5 @@
+# About
+
 Booleans in F# are represented by the `bool` type, which values can be either `true` or `false`.
 
 F# supports three [boolean operators][operators]: `not` (NOT), `&&` (AND), and `||` (OR). The `&&` and `||` operators use _short-circuit evaluation_, which means that the right-hand side of the operator is only evaluated when needed.

--- a/concepts/booleans/introduction.md
+++ b/concepts/booleans/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Booleans in F# are represented by the `bool` type, which values can be either `true` or `false`.
 
 F# supports three boolean operators: `not` (NOT), `&&` (AND), and `||` (OR).

--- a/concepts/classes/about.md
+++ b/concepts/classes/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on classes concept

--- a/concepts/classes/introduction.md
+++ b/concepts/classes/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for classes concept

--- a/concepts/conditionals/about.md
+++ b/concepts/conditionals/about.md
@@ -1,3 +1,5 @@
+# About
+
 Conditionally executing code can be done using [`if/elif/else` expressions][conditional-expression]. The condition(s) used in an `if/elif/else` expression must be of type `bool`. F# has no concept of _truthy_ values.
 
 ```fsharp

--- a/concepts/conditionals/introduction.md
+++ b/concepts/conditionals/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In this exercise you must conditionally execute logic. The most common way to do this in F# is by using an `if/elif/else` statement:
 
 ```fsharp

--- a/concepts/datetimes/about.md
+++ b/concepts/datetimes/about.md
@@ -1,3 +1,5 @@
+# About
+
 A `DateTime` in F# is an immutable object that contains both date _and_ time information. The date and time information can be accessed through its built-in [properties][properties].
 
 Manipulating a `DateTime` can be done by calling one of its [methods][methods]. As `DateTime` values can never change after having been defined, all methods that appear to modify a `DateTime` will actually return a new `DateTime`.

--- a/concepts/datetimes/introduction.md
+++ b/concepts/datetimes/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A `DateTime` in F# is an immutable object that contains both date _and_ time information. `DateTime` instances are manipulated by calling their methods. Once a `DateTime` has been constructed, its value can never change. Any methods/functions that appear to modify a `DateTime` will actually return a new `DateTime`.
 
 The textual representation of dates and times is dependent on the _culture_. Consider a `DateTime` with its date set to March 28 2019 and its time set to 14:30:59. Converting this `DateTime` to a `string` when using the `en-US` culture (American English) returns `"3/28/19 2:30:59 PM"`. When using the `fr-BE` culture (Belgian French), the same code returns a different value: `"28/03/19 14:30:59"`.

--- a/concepts/discriminated-unions/about.md
+++ b/concepts/discriminated-unions/about.md
@@ -1,3 +1,5 @@
+# About
+
 The [discriminated union][define] type represents a fixed number of named cases. Each value of a discriminated union corresponds to exactly one of the named cases. This type of data type is known as a _sum type_.
 
 Each case of a discriminated union can optionally have data associated with it, and different cases can have different types of data. If none of the cases have data associated with them, the discriminated union is similar to what other languages usually refer to as an _enumeration_ (or _enum_).

--- a/concepts/discriminated-unions/introduction.md
+++ b/concepts/discriminated-unions/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 The discriminated union type represents a fixed number of named cases. Each value of a discriminated union corresponds to exactly one of the named cases.
 
 A discriminated union is defined using the `type` keyword, with cases separated by pipe (`|`) characters:

--- a/concepts/floating-point-numbers/about.md
+++ b/concepts/floating-point-numbers/about.md
@@ -1,3 +1,5 @@
+# About
+
 A floating-point number is a number with zero or more digits behind the decimal separator. Examples are `-2.4`, `0.1`, `3.14`, `16.984025` and `1024.0`.
 
 F# has three floating-point types:

--- a/concepts/floating-point-numbers/introduction.md
+++ b/concepts/floating-point-numbers/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A floating-point number is a number with zero or more digits behind the decimal separator. Examples are `-2.4`, `0.1`, `3.14`, `16.984025` and `1024.0`.
 
 F# has three floating-point types:

--- a/concepts/higher-order-functions/about.md
+++ b/concepts/higher-order-functions/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on higher-order-functions concept

--- a/concepts/higher-order-functions/introduction.md
+++ b/concepts/higher-order-functions/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for higher-order-functions concept

--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -1,3 +1,5 @@
+# About
+
 A [`list`][lists] in F# is an immutable collection of zero or more values. The values in a list must all have the same type. As lists are immutable, once a list has been constructed, its value can never change. F# list have a _head_ (the first element) and a _tail_ (everything after the first element). The tail of a list is itself a list.
 
 Lists can be defined as follows:

--- a/concepts/lists/introduction.md
+++ b/concepts/lists/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A `list` in F# is an immutable collection of zero or more values. The values in a list must all have the same type. As lists are immutable, once a list has been constructed, its value can never change. Any functions/operators that appear to modify a list (such as adding an element), will actually return a new list.
 
 Lists can be defined as follows:

--- a/concepts/numbers/about.md
+++ b/concepts/numbers/about.md
@@ -1,3 +1,5 @@
+# About
+
 One of the key aspects of working with numbers in F# is the distinction between integers (numbers with no digits after the decimal separator) and floating-point numbers (numbers with zero or more digits after the decimal separator).
 
 The two most commonly used numeric types in F# are `int` (a 32-bit integer) and `float` (a 64-bit floating-point number).

--- a/concepts/numbers/introduction.md
+++ b/concepts/numbers/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 There are two different types of numbers in F#:
 
 - Integers: numbers with no digits behind the decimal separator (whole numbers). Examples are `-6`, `0`, `1`, `25`, `976` and `500000`.

--- a/concepts/pattern-matching/about.md
+++ b/concepts/pattern-matching/about.md
@@ -1,3 +1,5 @@
+# About
+
 An `if/elif/else` expression can be used to conditionally execute logic. F# also has another, more powerful way to conditionally execute logic: [pattern matching][pattern-matching]. With pattern matching, a value can be tested against one or more _patterns_. An example of such a pattern is the [_constant pattern_][constant-pattern], which matches a value against a constant (e.g. `1` or `"hello"`).
 
 In F#, pattern matching is done through the `match` keyword:

--- a/concepts/pattern-matching/introduction.md
+++ b/concepts/pattern-matching/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 An `if/elif/else` expression can be used to conditionally execute logic. F# also has another, more powerful way to conditionally execute logic: pattern matching. With pattern matching, a value can be tested against one or more _patterns_. An example of such a pattern is the _constant pattern_, which matches a value against a constant (e.g. `1` or `"hello"`).
 
 In F#, pattern matching is done through the `match` keyword:

--- a/concepts/records/about.md
+++ b/concepts/records/about.md
@@ -1,3 +1,5 @@
+# About
+
 A [record][records] is a collection of fields (which can be of different types) that belong together. To [define a record][define] the `type` keyword is used. A record's fields are defined between `{` and `}` characters, and each field has a name _and_ a type.
 
 ```fsharp

--- a/concepts/records/introduction.md
+++ b/concepts/records/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A record is a collection of fields (which can be of different types) that belong together. To define a record the `type` keyword is used. A record's fields are defined between `{` and `}` characters, and each field has a name _and_ a type. To create a record, specify the names of the fields and assign a value to them between `{` and `}` characters. All fields must be assigned a value when creating a record. A record instance's field values can be accessed using dot-notation.
 
 When defining/create a record, each field must either be on a separate line or separated by semicolons (`;`) when on a single line.

--- a/concepts/recursion/about.md
+++ b/concepts/recursion/about.md
@@ -1,3 +1,5 @@
+# About
+
 The ability for something to be defined in terms of itself is called recursion. In F#, recursion is most commonly found in [recursive functions][recursive-functions], which are functions that call themselves.
 
 A recursive function needs to have at least one _base case_ and at least one _recursive case_. A _base case_ returns a value without calling the function again. A _recursive case_ calls the function again, modifying the input so that it will at some point match the base case.

--- a/concepts/recursion/introduction.md
+++ b/concepts/recursion/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 The ability for something to be defined in terms of itself is called recursion. In F#, recursion is most commonly found in recursive functions, which are functions that call themselves.
 
 A recursive function needs to have at least one _base case_ and at least one _recursive case_. A _base case_ returns a value without calling the function again. A _recursive case_ calls the function again, modifying the input so that it will at some point match the base case.

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -1,3 +1,5 @@
+# About
+
 F# strings are immutable objects representing text as a sequence of Unicode characters (letters, digits, punctuation, etc.). Double quotes are used to define a `string` instance:
 
 ```fsharp

--- a/concepts/strings/introduction.md
+++ b/concepts/strings/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A `string` in F# is an object that represents immutable text as a sequence of Unicode characters (letters, digits, punctuation, etc.) and is defined as follows:
 
 ```fsharp

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 [F#](http://www.tryfsharp.org/Explore) is a strongly-typed, functional language that is part of Microsoft's .NET language stack.
 
 Although F# is great for data science problems, it can elegantly handle almost every problem you throw at it. 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 ### Installing .NET Core
 
 The F# track is built on top of the [.NET Core](https://www.microsoft.com/net/core/platform) platform, which runs on Windows, Linux and macOS. To build .NET Core projects, you can use the .NET Core Command Line Interface (CLI). This CLI is part of the .NET Core SDK, which you can install by following the [installation instructions](https://www.microsoft.com/net/download/core). Note: the F# track requires SDK version 3.0 or greater.

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,4 +1,4 @@
-## Learning F# 
+# Learning F# 
 
 ### Websites
 * The [F# Hello World tutorial](https://dotnet.microsoft.com/learn/languages/fsharp-hello-world-tutorial/intro) is a nice and gentle introduction to working with F#.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 ## Recommended Learning Resources
 
 ### Blogs

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 ## Running Tests
 
 To run the tests, execute the following command:

--- a/exercises/concept/annalyns-infiltration/.docs/hints.md
+++ b/exercises/concept/annalyns-infiltration/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - There are three [boolean operators][operators] to work with boolean values.

--- a/exercises/concept/annalyns-infiltration/.docs/instructions.md
+++ b/exercises/concept/annalyns-infiltration/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise, you'll be implementing the quest logic for a new RPG game a friend is developing. The game's main character is Annalyn, a brave girl with a fierce and loyal pet dog. Unfortunately, disaster strikes, as her best friend was kidnapped while searching for berries in the forest. Annalyn will try to find and free her best friend, optionally taking her dog with her on this quest.
 
 After some time spent following her best friend's trail, she finds the camp in which her best friend is imprisoned. It turns out there are two kidnappers: a mighty knight and a cunning archer.

--- a/exercises/concept/annalyns-infiltration/.docs/introduction.md
+++ b/exercises/concept/annalyns-infiltration/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Booleans in F# are represented by the `bool` type, which values can be either `true` or `false`.
 
 F# supports three boolean operators: `not` (NOT), `&&` (AND), and `||` (OR).

--- a/exercises/concept/annalyns-infiltration/.meta/design.md
+++ b/exercises/concept/annalyns-infiltration/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know of the existence of the `bool` type and its two values.

--- a/exercises/concept/bandwagoner/.docs/hints.md
+++ b/exercises/concept/bandwagoner/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ### 1. Define the model
 
 - [This page][define] shows how to define a discriminated union.

--- a/exercises/concept/bandwagoner/.docs/instructions.md
+++ b/exercises/concept/bandwagoner/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you're a big sports fan and you've just discovered a passion for NBA basketball. Being new to NBA basketball, you're doing a deep dive into NBA history, keeping track of teams, coaches, their win/loss stats and comparing them against each other.
 
 As you don't yet have a favorite team, you'll also be developing an algorithm to figure out whether to root for a particular team.

--- a/exercises/concept/bandwagoner/.docs/introduction.md
+++ b/exercises/concept/bandwagoner/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A record is a collection of fields (which can be of different types) that belong together. To define a record the `type` keyword is used. A record's fields are defined between `{` and `}` characters, and each field has a name _and_ a type. To create a record, specify the names of the fields and assign a value to them between `{` and `}` characters. All fields must be assigned a value when creating a record. A record instance's field values can be accessed using dot-notation.
 
 When defining/create a record, each field must either be on a separate line or separated by semicolons (`;`) when on a single line.

--- a/exercises/concept/bandwagoner/.meta/design.md
+++ b/exercises/concept/bandwagoner/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what a record is

--- a/exercises/concept/bird-watcher/.docs/hints.md
+++ b/exercises/concept/bird-watcher/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - The bird counts arrays always contain exactly 7 integers.

--- a/exercises/concept/bird-watcher/.docs/instructions.md
+++ b/exercises/concept/bird-watcher/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 You're an avid bird watcher that keeps track of how many birds have visited your garden in the last seven days.
 
 You have six tasks, all dealing with the numbers of birds that visited your garden.

--- a/exercises/concept/bird-watcher/.docs/introduction.md
+++ b/exercises/concept/bird-watcher/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 An `array` in F# is a mutable collection of zero or more values with a fixed length. This means that once an array has been created, its size cannot change, but its values can. The values in an array must all have the same type. Arrays can be defined as follows:
 
 ```fsharp

--- a/exercises/concept/bird-watcher/.meta/design.md
+++ b/exercises/concept/bird-watcher/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know of the existence of the `Array` type

--- a/exercises/concept/booking-up-for-beauty/.docs/hints.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - To work with the `DateTime` class, the `System` namespace has to be _opened_.

--- a/exercises/concept/booking-up-for-beauty/.docs/instructions.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you'll be working on an appointment scheduler for a beauty salon in New York that opened on September 15th in 2012.
 
 You have four tasks, which will all involve appointment dates. The dates and times will use one of the following three formats:

--- a/exercises/concept/booking-up-for-beauty/.docs/introduction.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A `DateTime` in F# is an immutable object that contains both date _and_ time information. `DateTime` instances are manipulated by calling their methods. Once a `DateTime` has been constructed, its value can never change. Any methods/functions that appear to modify a `DateTime` will actually return a new `DateTime`.
 
 The textual representation of dates and times is dependent on the _culture_. Consider a `DateTime` with its date set to March 28 2019 and its time set to 14:30:59. Converting this `DateTime` to a `string` when using the `en-US` culture (American English) returns `"3/28/19 2:30:59 PM"`. When using the `fr-BE` culture (Belgian French), the same code returns a different value: `"28/03/19 14:30:59"`.

--- a/exercises/concept/booking-up-for-beauty/.meta/design.md
+++ b/exercises/concept/booking-up-for-beauty/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know of the existence of the `DateTime` type.

--- a/exercises/concept/cars-assemble/.docs/hints.md
+++ b/exercises/concept/cars-assemble/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## 1. Calculate the production rate per second
 
 - Determining the success rate can be done through a [conditional expression][conditional-expression].

--- a/exercises/concept/cars-assemble/.docs/instructions.md
+++ b/exercises/concept/cars-assemble/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you'll be writing code to analyze the production of an assembly line in a car factory. The assembly line's speed can range from `0` (off) to `10` (maximum).
 
 At its lowest speed (`1`), `221` cars are produced each hour. The production increases linearly with the speed. So with the speed set to `4`, it should produce `4 * 221 = 884` cars per hour. However, higher speeds increase the likelihood that faulty cars are produced, which then have to be discarded. The following table shows how speed influences the success rate:

--- a/exercises/concept/cars-assemble/.docs/introduction.md
+++ b/exercises/concept/cars-assemble/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Numbers
 
 There are two different types of numbers in F#:

--- a/exercises/concept/cars-assemble/.meta/design.md
+++ b/exercises/concept/cars-assemble/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know of the existence of the two most commonly used number types, `int` and `float`.

--- a/exercises/concept/guessing-game/.docs/hints.md
+++ b/exercises/concept/guessing-game/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - [This page][pattern-matching] has a nice introduction to pattern matching in F#.

--- a/exercises/concept/guessing-game/.docs/instructions.md
+++ b/exercises/concept/guessing-game/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise, you are playing a number guessing game with a friend. The rules are simple: you secretly choose a number between `1` and `100` and your friend tries to guess what number you've chosen. To help your friend, you respond differently depending on how close the guess was to the number you've chosen (`42`). These are the rules for the different replies:
 
 - If the guess is `42`: "Correct"

--- a/exercises/concept/guessing-game/.docs/introduction.md
+++ b/exercises/concept/guessing-game/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 An `if/elif/else` expression can be used to conditionally execute logic. F# also has another, more powerful way to conditionally execute logic: pattern matching. With pattern matching, a value can be tested against one or more _patterns_. An example of such a pattern is the _constant pattern_, which matches a value against a constant (e.g. `1` or `"hello"`).
 
 In F#, pattern matching is done through the `match` keyword:

--- a/exercises/concept/guessing-game/.meta/design.md
+++ b/exercises/concept/guessing-game/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what pattern matching is.

--- a/exercises/concept/interest-is-interesting/.docs/hints.md
+++ b/exercises/concept/interest-is-interesting/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## 1. Calculate the interest rate
 
 - By default, any floating-point number defined in F# code is treated as a `float`. To use a different floating-point type (like `single` or `decimal`), one must add the appropriate [suffix][literals] to the number.

--- a/exercises/concept/interest-is-interesting/.docs/instructions.md
+++ b/exercises/concept/interest-is-interesting/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you'll be working with savings accounts. Each year, the balance of your savings account is updated based on its interest rate. The interest rate your bank gives you depends on the amount of money in your account (its balance):
 
 - -3.213% for a negative balance.

--- a/exercises/concept/interest-is-interesting/.docs/introduction.md
+++ b/exercises/concept/interest-is-interesting/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A floating-point number is a number with zero or more digits behind the decimal separator. Examples are `-2.4`, `0.1`, `3.14`, `16.984025` and `1024.0`.
 
 F# has three floating-point types:

--- a/exercises/concept/interest-is-interesting/.meta/design.md
+++ b/exercises/concept/interest-is-interesting/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know of the existence of the three floating point types: `double`, `float` and `decimal`.

--- a/exercises/concept/log-levels/.docs/hints.md
+++ b/exercises/concept/log-levels/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - The `string` class has many useful [built-in methods][methods].

--- a/exercises/concept/log-levels/.docs/instructions.md
+++ b/exercises/concept/log-levels/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you'll be processing log-lines.
 
 Each log line is a string formatted as follows: `"[<LEVEL>]: <MESSAGE>"`.

--- a/exercises/concept/log-levels/.docs/introduction.md
+++ b/exercises/concept/log-levels/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A `string` in F# is an object that represents immutable text as a sequence of Unicode characters (letters, digits, punctuation, etc.) and is defined as follows:
 
 ```fsharp

--- a/exercises/concept/log-levels/.meta/design.md
+++ b/exercises/concept/log-levels/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know of the existence of the `string` type.

--- a/exercises/concept/lucians-luscious-lasagna/.docs/hints.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - An integer value can be defined as one or more consecutive digits.

--- a/exercises/concept/lucians-luscious-lasagna/.docs/instructions.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you're going to write some code to help you cook a brilliant lasagna from your favorite cooking book.
 
 You have four tasks, all related to the time spent cooking the lasagna.

--- a/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In F#, assigning a value to a name is referred to as a _binding_. Bindings are immutable, which makes them similar to constants in other languages. As F# is a statically-typed language, each binding has a type at compile-time.
 
 Bindings are defined using the `let` keyword. Specifying a binding's type is optional for most bindings, as F#'s _type inference_ can usually infer the type based on their value. A binding looks like this:

--- a/exercises/concept/lucians-luscious-lasagna/.meta/design.md
+++ b/exercises/concept/lucians-luscious-lasagna/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what a value is.

--- a/exercises/concept/pizza-pricing/.docs/hints.md
+++ b/exercises/concept/pizza-pricing/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Try to split a problem into a base case and a recursive case. For example, let's say you want to count how many cookies are there in the cookie jar with a recursive approach. A base case is an empty jar - it has zero cookies. If the jar is not empty, then the number of cookies in the jar is equal to one cookie plus the number of cookies in the jar after removing one cookie.

--- a/exercises/concept/pizza-pricing/.docs/instructions.md
+++ b/exercises/concept/pizza-pricing/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you're working at a pizza place that delivers to customers.
 
 You offer three types of pizzas:

--- a/exercises/concept/pizza-pricing/.docs/introduction.md
+++ b/exercises/concept/pizza-pricing/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 The ability for something to be defined in terms of itself is called recursion. In F#, recursion is most commonly found in recursive functions, which are functions that call themselves.
 
 A recursive function needs to have at least one _base case_ and at least one _recursive case_. A _base case_ returns a value without calling the function again. A _recursive case_ calls the function again, modifying the input so that it will at some point match the base case.

--- a/exercises/concept/pizza-pricing/.meta/design.md
+++ b/exercises/concept/pizza-pricing/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what recursion is.

--- a/exercises/concept/tracks-on-tracks-on-tracks/.docs/hints.md
+++ b/exercises/concept/tracks-on-tracks-on-tracks/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## 1. Create a new list
 
 - How to define an empty list can be found on [this page][create-and-initialize].

--- a/exercises/concept/tracks-on-tracks-on-tracks/.docs/instructions.md
+++ b/exercises/concept/tracks-on-tracks-on-tracks/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you'll be writing code to keep track of a list of programming languages you want to learn on Exercism.
 
 You have six tasks, which will all involve dealing with lists.

--- a/exercises/concept/tracks-on-tracks-on-tracks/.docs/introduction.md
+++ b/exercises/concept/tracks-on-tracks-on-tracks/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A `list` in F# is an immutable collection of zero or more values. The values in a list must all have the same type. As lists are immutable, once a list has been constructed, its value can never change. Any functions/operators that appear to modify a list (such as adding an element), will actually return a new list.
 
 Lists can be defined as follows:

--- a/exercises/concept/tracks-on-tracks-on-tracks/.meta/design.md
+++ b/exercises/concept/tracks-on-tracks-on-tracks/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know of the existence of the `list` type.

--- a/exercises/concept/valentines-day/.docs/hints.md
+++ b/exercises/concept/valentines-day/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## 1. Define the approval
 
 - [This page][define] shows how to define a discriminated union.

--- a/exercises/concept/valentines-day/.docs/instructions.md
+++ b/exercises/concept/valentines-day/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise, it's Valentine's day and you and your partner are planning on doing something nice together. Your partner has lots of ideas, and is now asking you to rate the ideas, in order to find the activity to engage in.
 
 The following ideas are proposed by your partner:

--- a/exercises/concept/valentines-day/.docs/introduction.md
+++ b/exercises/concept/valentines-day/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 The discriminated union type represents a fixed number of named cases. Each value of a discriminated union corresponds to exactly one of the named cases.
 
 A discriminated union is defined using the `type` keyword, with cases separated by pipe (`|`) characters:

--- a/exercises/concept/valentines-day/.meta/design.md
+++ b/exercises/concept/valentines-day/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what discriminated unions are.

--- a/exercises/practice/accumulate/.meta/hints.md
+++ b/exercises/practice/accumulate/.meta/hints.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 For this exercise the following F# feature comes in handy:
 - [Tail recursion](https://blogs.msdn.microsoft.com/fsharpteam/2011/07/08/tail-calls-in-f/) Prevent stack overflows with large input by using tail recursion. While there are no test cases checking explicitly for this, using tail recursion leads to a more performant solution. Another good resource on tail recursion is [this blog post](http://blog.ploeh.dk/2015/12/22/tail-recurse/).
 - [Type inference](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/generics/#implicitly-generic-constructs) The F# compiler can automatically infer types, which means you often don't have to add any types at all. For more information on how this works and its advantages, see [this page](https://fsharpforfunandprofit.com/posts/type-inference/).

--- a/exercises/practice/alphametics/.meta/hints.md
+++ b/exercises/practice/alphametics/.meta/hints.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 - To parse the text, you could try to use the [FParsec](http://www.quanttec.com/fparsec/tutorial.html) library. 
 - You can solve this exercise with a brute force algorithm, but this will possibly have a poor runtime performance.
 Try to find a more sophisticated solution. Hint: You could try the column-wise addition algorithm that is usually taught in school.

--- a/exercises/practice/beer-song/.meta/hints.md
+++ b/exercises/practice/beer-song/.meta/hints.md
@@ -1,2 +1,2 @@
-## Hints
+# Hints
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/diamond/.meta/hints.md
+++ b/exercises/practice/diamond/.meta/hints.md
@@ -1,2 +1,2 @@
-## Hints
+# Hints
 - Testing this one can be tricky without simply hardcoding a bunch of inputs and outputs. [Property based testing](https://fsharpforfunandprofit.com/posts/property-based-testing/) is another way to think about testing that allows you to more easily test this type of algorithm.

--- a/exercises/practice/difference-of-squares/.meta/hints.md
+++ b/exercises/practice/difference-of-squares/.meta/hints.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 For this exercise the following F# features come in handy:
 - The [range operator](https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/operators.%5B-..-%5D%5B%5Et%5D-function-%5Bfsharp%5D) allows you to succinctly create a range of values.
 - [List.sumBy](https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/list.sumby%5B't,%5Eu%5D-function-%5Bfsharp%5D) is a condensed format to apply a function to a list and then sum the results.

--- a/exercises/practice/diffie-hellman/.meta/hints.md
+++ b/exercises/practice/diffie-hellman/.meta/hints.md
@@ -1,3 +1,3 @@
-## Hints
+# Hints
 For this exercise the following F# feature comes in handy:
 - [BigInt](https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/numerics.biginteger-structure-%5Bfsharp%5D)

--- a/exercises/practice/food-chain/.meta/hints.md
+++ b/exercises/practice/food-chain/.meta/hints.md
@@ -1,2 +1,2 @@
-## Hints
+# Hints
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/grade-school/.meta/hints.md
+++ b/exercises/practice/grade-school/.meta/hints.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 For this exercise the following F# feature comes in handy:
 - The [Map](https://en.wikibooks.org/wiki/F_Sharp_Programming/Sets_and_Maps#Maps) type associates keys with values. It is very similar to .NET's `Dictionary<TKey, TValue>` type, but with one major difference: `Map` is [immutable](https://fsharpforfunandprofit.com/posts/correctness-immutability/).
 - A [type abbreviation](https://fsharpforfunandprofit.com/posts/type-abbreviations/) is used to create a descriptive alias for a more complex type.

--- a/exercises/practice/grains/.meta/hints.md
+++ b/exercises/practice/grains/.meta/hints.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 For this exercise the following F# features come in handy:
 - [BigInt](https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/numerics.biginteger-structure-%5Bfsharp%5D)
 - [Seq.sumBy](https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/seq.sumby%5B't,%5Eu%5D-function-%5Bfsharp%5D) is a condensed format to apply a function to a sequence and then sum the results

--- a/exercises/practice/house/.meta/hints.md
+++ b/exercises/practice/house/.meta/hints.md
@@ -1,2 +1,2 @@
-## Hints
+# Hints
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/leap/.meta/hints.md
+++ b/exercises/practice/leap/.meta/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## Notes
 
 The DateTime class in F# provides a built-in [IsLeapYear](https://msdn.microsoft.com/en-us/library/system.datetime.isleapyear(v=vs.110).aspx?cs-save-lang=1&cs-lang=fsharp) method

--- a/exercises/practice/lens-person/.meta/hints.md
+++ b/exercises/practice/lens-person/.meta/hints.md
@@ -1,2 +1,2 @@
-## Hints
+# Hints
 - This exercise expects you to use the [Aether](https://xyncro.tech/aether/) library, which adds *lenses* functionality to F#. With lenses, you can quite easily read or update nested structures. 

--- a/exercises/practice/linked-list/.meta/hints.md
+++ b/exercises/practice/linked-list/.meta/hints.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 A [doubly linked list](https://en.wikipedia.org/wiki/Doubly_linked_list) is a mutable data structure. As F# is a functional-first language, immutability is generally preferred, but there are language features that allow the use of mutation where it is required.
 

--- a/exercises/practice/nth-prime/.meta/hints.md
+++ b/exercises/practice/nth-prime/.meta/hints.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 For this exercise the following F# feature comes in handy:
 - [Sequences](https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/sequences) are evaluated lazily. They allows you to work with an infinite sequence of values.
 

--- a/exercises/practice/palindrome-products/.meta/hints.md
+++ b/exercises/practice/palindrome-products/.meta/hints.md
@@ -1,2 +1,2 @@
-## Hints
+# Hints
 - The most simple way to check if a number is a palindrome is quite slow. To speed things up, you could implement a slighly more complex algorithm which uses mutable state.

--- a/exercises/practice/parallel-letter-frequency/.meta/hints.md
+++ b/exercises/practice/parallel-letter-frequency/.meta/hints.md
@@ -1,3 +1,3 @@
-## Hints
+# Hints
 For this exercise the following F# feature comes in handy:
 - [Asynchronous programming](https://fsharpforfunandprofit.com/posts/concurrency-async-and-parallel/) .NET has asynchronous functionality built-in which enables you to run things in parallel (assuming you have a multi-core processor which is becoming more an more common) easily

--- a/exercises/practice/poker/.meta/hints.md
+++ b/exercises/practice/poker/.meta/hints.md
@@ -1,2 +1,2 @@
-## Hints
+# Hints
 - [Designing with types](http://fsharpforfunandprofit.com/series/designing-with-types.html) To come up with a clean and easy to read solution for this make sure to choose the right types to represent the different parts of the problem (think of suits, values, cards, etc)

--- a/exercises/practice/proverb/.meta/hints.md
+++ b/exercises/practice/proverb/.meta/hints.md
@@ -1,2 +1,2 @@
-## Hints
+# Hints
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/raindrops/.meta/hints.md
+++ b/exercises/practice/raindrops/.meta/hints.md
@@ -1,2 +1,2 @@
-## Hints
+# Hints
 - Think of this in a generic way. If you're familiar with the (fizz buzz)[https://en.wikipedia.org/wiki/Fizz_buzz] problem this is similar except there are three conditions instead of two. How would you implement this knowing that one day we might want to extend to four, five, or even ten types of raindrops?

--- a/exercises/practice/rna-transcription/.meta/hints.md
+++ b/exercises/practice/rna-transcription/.meta/hints.md
@@ -1,3 +1,3 @@
-## Hints
+# Hints
 For this exercise the following F# feature comes in handy:
 - [Match Expressions](https://fsharpforfunandprofit.com/posts/match-expression/) While this can be solved using a dictionary, using a match expression is more idiomatic.

--- a/exercises/practice/space-age/.meta/hints.md
+++ b/exercises/practice/space-age/.meta/hints.md
@@ -1,3 +1,3 @@
-## Hints
+# Hints
 - Try to focus on minimizing the amount of code duplication. If you find yourself doing a lot of copy/paste take a step back and think about how the code can be refactored
 - [Pattern matching](https://fsharpforfunandprofit.com/posts/match-expression/) is more idiomatic than using dictionaries to translate values

--- a/exercises/practice/twelve-days/.meta/hints.md
+++ b/exercises/practice/twelve-days/.meta/hints.md
@@ -1,2 +1,2 @@
-## Hints
+# Hints
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/wordy/.meta/hints.md
+++ b/exercises/practice/wordy/.meta/hints.md
@@ -1,3 +1,3 @@
-## Hints
+# Hints
 - To parse the text, you could try to use the [FParsec](http://www.quanttec.com/fparsec/tutorial.html) library.
 - As an exercise, you could try to represent a question as an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree).


### PR DESCRIPTION
Add level one headings to Markdown files.\n\n

See https://github.com/exercism/configlet/issues/150#issuecomment-772762259 for the rationale of these changes.

The full specification can be found [here](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md).