### PR TITLE
🤖 Add blurb to .meta/config.json files

### DIFF
--- a/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -5,10 +5,19 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "forked_from": ["javascript/booleans"],
+  "forked_from": [
+    "javascript/booleans"
+  ],
   "files": {
-    "solution": ["AnnalynsInfiltration.fs"],
-    "test": ["AnnalynsInfiltrationTests.fs"],
-    "exemplar": [".meta/Exemplar.fs"]
-  }
+    "solution": [
+      "AnnalynsInfiltration.fs"
+    ],
+    "test": [
+      "AnnalynsInfiltrationTests.fs"
+    ],
+    "exemplar": [
+      ".meta/Exemplar.fs"
+    ]
+  },
+  "blurb": "TODO: add blurb for annalyns-infiltration exercise"
 }

--- a/exercises/concept/bandwagoner/.meta/config.json
+++ b/exercises/concept/bandwagoner/.meta/config.json
@@ -12,8 +12,15 @@
     }
   ],
   "files": {
-    "solution": ["Bandwagoner.fs"],
-    "test": ["BandwagonerTests.fs"],
-    "exemplar": [".meta/Exemplar.fs"]
-  }
+    "solution": [
+      "Bandwagoner.fs"
+    ],
+    "test": [
+      "BandwagonerTests.fs"
+    ],
+    "exemplar": [
+      ".meta/Exemplar.fs"
+    ]
+  },
+  "blurb": "TODO: add blurb for bandwagoner exercise"
 }

--- a/exercises/concept/bird-watcher/.meta/config.json
+++ b/exercises/concept/bird-watcher/.meta/config.json
@@ -5,10 +5,19 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "forked_from": ["csharp/arrays"],
+  "forked_from": [
+    "csharp/arrays"
+  ],
   "files": {
-    "solution": ["BirdWatcher.fs"],
-    "test": ["BirdWatcherTests.fs"],
-    "exemplar": [".meta/Exemplar.fs"]
-  }
+    "solution": [
+      "BirdWatcher.fs"
+    ],
+    "test": [
+      "BirdWatcherTests.fs"
+    ],
+    "exemplar": [
+      ".meta/Exemplar.fs"
+    ]
+  },
+  "blurb": "TODO: add blurb for bird-watcher exercise"
 }

--- a/exercises/concept/booking-up-for-beauty/.meta/config.json
+++ b/exercises/concept/booking-up-for-beauty/.meta/config.json
@@ -5,10 +5,19 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "forked_from": ["csharp/datetimes"],
+  "forked_from": [
+    "csharp/datetimes"
+  ],
   "files": {
-    "solution": ["BookingUpForBeauty.fs"],
-    "test": ["BookingUpForBeautyTests.fs"],
-    "exemplar": [".meta/Exemplar.fs"]
-  }
+    "solution": [
+      "BookingUpForBeauty.fs"
+    ],
+    "test": [
+      "BookingUpForBeautyTests.fs"
+    ],
+    "exemplar": [
+      ".meta/Exemplar.fs"
+    ]
+  },
+  "blurb": "TODO: add blurb for booking-up-for-beauty exercise"
 }

--- a/exercises/concept/cars-assemble/.meta/config.json
+++ b/exercises/concept/cars-assemble/.meta/config.json
@@ -5,10 +5,19 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "forked_from": ["csharp/numbers"],
+  "forked_from": [
+    "csharp/numbers"
+  ],
   "files": {
-    "solution": ["CarsAssemble.fs"],
-    "test": ["CarsAssembleTests.fs"],
-    "exemplar": [".meta/Exemplar.fs"]
-  }
+    "solution": [
+      "CarsAssemble.fs"
+    ],
+    "test": [
+      "CarsAssembleTests.fs"
+    ],
+    "exemplar": [
+      ".meta/Exemplar.fs"
+    ]
+  },
+  "blurb": "TODO: add blurb for cars-assemble exercise"
 }

--- a/exercises/concept/guessing-game/.meta/config.json
+++ b/exercises/concept/guessing-game/.meta/config.json
@@ -6,8 +6,15 @@
     }
   ],
   "files": {
-    "solution": ["GuessingGame.fs"],
-    "test": ["GuessingGameTests.fs"],
-    "exemplar": [".meta/Exemplar.fs"]
-  }
+    "solution": [
+      "GuessingGame.fs"
+    ],
+    "test": [
+      "GuessingGameTests.fs"
+    ],
+    "exemplar": [
+      ".meta/Exemplar.fs"
+    ]
+  },
+  "blurb": "TODO: add blurb for guessing-game exercise"
 }

--- a/exercises/concept/interest-is-interesting/.meta/config.json
+++ b/exercises/concept/interest-is-interesting/.meta/config.json
@@ -5,10 +5,19 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "forked_from": ["csharp/floating-point-numbers"],
+  "forked_from": [
+    "csharp/floating-point-numbers"
+  ],
   "files": {
-    "solution": ["InterestIsInteresting.fs"],
-    "test": ["InterestIsInterestingTests.fs"],
-    "exemplar": [".meta/Exemplar.fs"]
-  }
+    "solution": [
+      "InterestIsInteresting.fs"
+    ],
+    "test": [
+      "InterestIsInterestingTests.fs"
+    ],
+    "exemplar": [
+      ".meta/Exemplar.fs"
+    ]
+  },
+  "blurb": "TODO: add blurb for interest-is-interesting exercise"
 }

--- a/exercises/concept/log-levels/.meta/config.json
+++ b/exercises/concept/log-levels/.meta/config.json
@@ -5,10 +5,19 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "forked_from": ["csharp/strings"],
+  "forked_from": [
+    "csharp/strings"
+  ],
   "files": {
-    "solution": ["LogLevels.fs"],
-    "test": ["LogLevelsTests.fs"],
-    "exemplar": [".meta/Exemplar.fs"]
-  }
+    "solution": [
+      "LogLevels.fs"
+    ],
+    "test": [
+      "LogLevelsTests.fs"
+    ],
+    "exemplar": [
+      ".meta/Exemplar.fs"
+    ]
+  },
+  "blurb": "TODO: add blurb for log-levels exercise"
 }

--- a/exercises/concept/lucians-luscious-lasagna/.meta/config.json
+++ b/exercises/concept/lucians-luscious-lasagna/.meta/config.json
@@ -6,8 +6,15 @@
     }
   ],
   "files": {
-    "solution": ["LuciansLusciousLasagna.fs"],
-    "test": ["LuciansLusciousLasagnaTests.fs"],
-    "exemplar": [".meta/Exemplar.fs"]
-  }
+    "solution": [
+      "LuciansLusciousLasagna.fs"
+    ],
+    "test": [
+      "LuciansLusciousLasagnaTests.fs"
+    ],
+    "exemplar": [
+      ".meta/Exemplar.fs"
+    ]
+  },
+  "blurb": "TODO: add blurb for lucians-luscious-lasagna exercise"
 }

--- a/exercises/concept/pizza-pricing/.meta/config.json
+++ b/exercises/concept/pizza-pricing/.meta/config.json
@@ -6,8 +6,15 @@
     }
   ],
   "files": {
-    "solution": ["PizzaPricing.fs"],
-    "test": ["PizzaPricingTests.fs"],
-    "exemplar": [".meta/Exemplar.fs"]
-  }
+    "solution": [
+      "PizzaPricing.fs"
+    ],
+    "test": [
+      "PizzaPricingTests.fs"
+    ],
+    "exemplar": [
+      ".meta/Exemplar.fs"
+    ]
+  },
+  "blurb": "TODO: add blurb for pizza-pricing exercise"
 }

--- a/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
+++ b/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
@@ -5,10 +5,19 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "forked_from": ["clojure/lists"],
+  "forked_from": [
+    "clojure/lists"
+  ],
   "files": {
-    "solution": ["TracksOnTracksOnTracks.fs"],
-    "test": ["TracksOnTracksOnTracksTests.fs"],
-    "exemplar": [".meta/Exemplar.fs"]
-  }
+    "solution": [
+      "TracksOnTracksOnTracks.fs"
+    ],
+    "test": [
+      "TracksOnTracksOnTracksTests.fs"
+    ],
+    "exemplar": [
+      ".meta/Exemplar.fs"
+    ]
+  },
+  "blurb": "TODO: add blurb for tracks-on-tracks-on-tracks exercise"
 }

--- a/exercises/concept/valentines-day/.meta/config.json
+++ b/exercises/concept/valentines-day/.meta/config.json
@@ -6,8 +6,15 @@
     }
   ],
   "files": {
-    "solution": ["ValentinesDay.fs"],
-    "test": ["ValentinesDayTests.fs"],
-    "exemplar": [".meta/Exemplar.fs"]
-  }
+    "solution": [
+      "ValentinesDay.fs"
+    ],
+    "test": [
+      "ValentinesDayTests.fs"
+    ],
+    "exemplar": [
+      ".meta/Exemplar.fs"
+    ]
+  },
+  "blurb": "TODO: add blurb for valentines-day exercise"
 }

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"
 }

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Convert a long phrase to its acronym",
   "source": "Julien Vanier",
   "source_url": "https://github.com/monkbroc"
 }

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East.",
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Affine_cipher"
 }

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base."
 }

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
   "source": "Jumpstart Lab Warm-up",
   "source_url": "http://jumpstartlab.com"
 }

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Write a function to solve alphametics puzzles."
 }

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"
 }

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Determine if a number is an Armstrong number",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number"
 }

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Atbash"
 }

--- a/exercises/practice/bank-account/.meta/config.json
+++ b/exercises/practice/bank-account/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!"
 }

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
   "source": "Learn to Program by Chris Pine",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"
 }

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Insert and search for numbers in a binary tree.",
   "source": "Josh Cheek",
   "source_url": "https://twitter.com/josh_cheek"
 }

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Implement a binary search algorithm.",
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm"
 }

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"
 }

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"
 }

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts of multiple-book purchases.",
   "source": "Inspired by the harry potter kata from Cyber-Dojo.",
   "source_url": "http://cyber-dojo.org"
 }

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Score a bowling game",
   "source": "The Bowling Game Kata at but UncleBob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"
 }

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Correctly determine change to be given using the least number of coins",
   "source": "Software Craftsmanship - Coin Change Kata",
   "source_url": "https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata"
 }

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end.",
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Circular_buffer"
 }

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Implement a clock that handles times without dates.",
   "source": "Pairing session with Erin Drummond",
   "source_url": "https://twitter.com/ebdrummond"
 }

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
   "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"
 }

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Implement complex numbers.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Complex_number"
 }

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Compute the result for a game of Hex / Polygon"
 }

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Implement the classic method for composing secret messages called a square code.",
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"
 }

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Create a custom set type."
 }

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -11,5 +11,6 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
   "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
 }

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.",
   "source": "Seb Rose",
   "source_url": "http://claysnow.co.uk/recycling-tests-in-tdd/"
 }

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "source": "Problem 6 at Project Euler",
   "source_url": "http://projecteuler.net/problem=6"
 }

--- a/exercises/practice/diffie-hellman/.meta/config.json
+++ b/exercises/practice/diffie-hellman/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Diffie-Hellman key exchange.",
   "source": "Wikipedia, 1024 bit key from www.cryptopp.com/wiki.",
   "source_url": "http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange"
 }

--- a/exercises/practice/dnd-character/.meta/config.json
+++ b/exercises/practice/dnd-character/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Randomly generate Dungeons & Dragons characters",
   "source": "Simon Shine, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/616#issuecomment-437358945"
 }

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Make a chain of dominoes."
 }

--- a/exercises/practice/dot-dsl/.meta/config.json
+++ b/exercises/practice/dot-dsl/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Write a Domain Specific Language similar to the Graphviz dot language",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/DOT_(graph_description_language)"
 }

--- a/exercises/practice/error-handling/.meta/config.json
+++ b/exercises/practice/error-handling/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Implement various kinds of error handling and resource management"
 }

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
   "source": "The Jumpstart Lab team",
   "source_url": "http://jumpstartlab.com"
 }

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'",
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly"
 }

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Implement an evaluator for a very simple subset of Forth"
 }

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=09"
 }

--- a/exercises/practice/go-counting/.meta/config.json
+++ b/exercises/practice/go-counting/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Count the scored points on a Go board."
 }

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
   "source": "A pairing session with Phil Battos at gSchool",
   "source_url": "http://gschool.it"
 }

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
   "source": "JavaRanch Cattle Drive, exercise 6",
   "source_url": "http://www.javaranch.com/grains.jsp"
 }

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line.",
   "source": "Conversation with Nate Foster.",
   "source_url": "http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf"
 }

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Calculate the Hamming difference between two DNA strands.",
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"
 }

--- a/exercises/practice/hangman/.meta/config.json
+++ b/exercises/practice/hangman/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Implement the logic of the hangman game using functional reactive programming."
 }

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"
 }

--- a/exercises/practice/hexadecimal/.meta/config.json
+++ b/exercises/practice/hexadecimal/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Convert a hexadecimal number, represented as a string (e.g. \"10af8c\"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/examples/NumberBases.html"
 }

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -11,5 +11,6 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Manage a player's High Score list",
   "source": "Tribute to the eighties' arcade game Frogger"
 }

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Output the nursery rhyme 'This is the House that Jack Built'.",
   "source": "British nursery rhyme",
   "source_url": "http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built"
 }

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Check if a given string is a valid ISBN-10 number.",
   "source": "Converting a string into a number and some basic processing utilizing a relatable real world example.",
   "source_url": "https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation"
 }

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Determine if a word or phrase is an isogram.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Isogram"
 }

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a diagram, determine which plants each child in the kindergarten class is responsible for.",
   "source": "Random musings during airplane trip.",
   "source_url": "http://jumpstartlab.com"
 }

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
   "source": "A variation on Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"
 }

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a year, report if it is a leap year.",
   "source": "JavaRanch Cattle Drive, exercise 3",
   "source_url": "http://www.javaranch.com/leap.jsp"
 }

--- a/exercises/practice/ledger/.meta/config.json
+++ b/exercises/practice/ledger/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Refactor a ledger printer."
 }

--- a/exercises/practice/lens-person/.meta/config.json
+++ b/exercises/practice/lens-person/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Use lenses to update nested records (specific to languages with immutable data)."
 }

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -11,5 +11,6 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Implement a doubly linked list",
   "source": "Classic computer science topic"
 }

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Implement basic list operations"
 }

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
   "source": "The Luhn Algorithm on Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm"
 }

--- a/exercises/practice/markdown/.meta/config.json
+++ b/exercises/practice/markdown/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Refactor a Markdown parser"
 }

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -11,5 +11,6 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Make sure the brackets and braces all match.",
   "source": "Ginna Baker"
 }

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a string representing a matrix of numbers, return the rows and columns of that matrix.",
   "source": "Warmup to the `saddle-points` warmup.",
   "source_url": "http://jumpstartlab.com"
 }

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Calculate the date of meetups.",
   "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
   "source_url": "https://twitter.com/copiousfreetime"
 }

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Add the numbers to a minesweeper board"
 }

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a number n, determine what the nth prime is.",
   "source": "A variation on Problem 7 at Project Euler",
   "source_url": "http://projecteuler.net/problem=7"
 }

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
   "source_url": "http://rosalind.info/problems/dna/"
 }

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.",
   "source": "Inspired by the Bank OCR kata",
   "source_url": "http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR"
 }

--- a/exercises/practice/octal/.meta/config.json
+++ b/exercises/practice/octal/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=base+8"
 }

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Detect palindrome products in a given range.",
   "source": "Problem 4 at Project Euler",
   "source_url": "http://projecteuler.net/problem=4"
 }

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Determine if a sentence is a pangram.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Pangram"
 }

--- a/exercises/practice/parallel-letter-frequency/.meta/config.json
+++ b/exercises/practice/parallel-letter-frequency/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Count the frequency of letters in texts using parallel computation."
 }

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Compute Pascal's triangle up to a given number of rows.",
   "source": "Pascal's Triangle at Wolfram Math World",
   "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html"
 }

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
   "source_url": "http://shop.oreilly.com/product/0636920029687.do"
 }

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
   "source": "Event Manager by JumpstartLab",
   "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html"
 }

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Implement a program that translates from English to Pig Latin",
   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",
   "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/"
 }

--- a/exercises/practice/poker/.meta/config.json
+++ b/exercises/practice/poker/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Pick the best hand(s) from a list of poker hands.",
   "source": "Inspired by the training course from Udacity.",
   "source_url": "https://www.udacity.com/course/viewer#!/c-cs212/"
 }

--- a/exercises/practice/pov/.meta/config.json
+++ b/exercises/practice/pov/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Reparent a graph on a selected node",
   "source": "Adaptation of exercise from 4clojure",
   "source_url": "https://www.4clojure.com/"
 }

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Compute the prime factors of a given natural number.",
   "source": "The Prime Factors Kata by Uncle Bob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata"
 }

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -11,5 +11,6 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Translate RNA sequences into proteins.",
   "source": "Tyler Long"
 }

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/For_Want_of_a_Nail"
 }

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
   "source": "Problem 9 at Project Euler",
   "source_url": "http://projecteuler.net/problem=9"
 }

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"
 }

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Implement encoding and decoding for the rail fence cipher.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher"
 }

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
   "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz"
 }

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Implement rational numbers.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Rational_number"
 }

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Implement a basic reactive system."
 }

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Count the rectangles in an ASCII diagram."
 }

--- a/exercises/practice/rest-api/.meta/config.json
+++ b/exercises/practice/rest-api/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Implement a RESTful API for tracking IOUs."
 }

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Reverse a string",
   "source": "Introductory challenge to reverse an input string",
   "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"
 }

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "source": "Hyperphysics",
   "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"
 }

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -11,5 +11,6 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Manage robot factory settings.",
   "source": "A debugging session with Paul Blackwell at gSchool."
 }

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Write a robot simulator.",
   "source": "Inspired by an interview question at a famous company.",
   "source_url": ""
 }

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
   "source": "The Roman Numeral Kata",
   "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals"
 }

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Caesar_cipher"
 }

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Implement run-length encoding and decoding.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Run-length_encoding"
 }

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Detect saddle points in a matrix.",
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"
 }

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
   "source": "A variation on JavaRanch CattleDrive, exercise 4a",
   "source_url": "http://www.javaranch.com/say.jsp"
 }

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Generate musical scales, given a starting note and a set of intervals. "
 }

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a word, compute the Scrabble score for that word.",
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"
 }

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
   "source": "Bert, in Mary Poppins",
   "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047"
 }

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
   "source": "A subset of the Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"
 }

--- a/exercises/practice/sgf-parsing/.meta/config.json
+++ b/exercises/practice/sgf-parsing/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Parsing a Smart Game Format string."
 }

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
   "source": "Sieve of Eratosthenes at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes"
 }

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Implement a simple shift cipher like Caesar and a more secure substitution cipher",
   "source": "Substitution Cipher at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Substitution_cipher"
 }

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Write a simple linked list implementation that uses Elements and a List",
   "source": "Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists.",
   "source_url": "https://web.archive.org/web/20160731005714/http://brpreiss.com/books/opus8/html/page96.html"
 }

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=01"
 }

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": " Given the size, return a square matrix of numbers in spiral order.",
   "source": "Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension.",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/"
 }

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"
 }

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Write a function to determine if a list is a sublist of another list."
 }

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
   "source": "A variation on Problem 1 at Project Euler",
   "source_url": "http://projecteuler.net/problem=1"
 }

--- a/exercises/practice/tournament/.meta/config.json
+++ b/exercises/practice/tournament/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Tally the results of a small football competition."
 }

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Take input text and output it transposed.",
   "source": "Reddit r/dailyprogrammer challenge #270 [Easy].",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text"
 }

--- a/exercises/practice/tree-building/.meta/config.json
+++ b/exercises/practice/tree-building/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Refactor a tree building algorithm."
 }

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
   "source": "The Ruby Koans triangle project, parts 1 & 2",
   "source_url": "http://rubykoans.com"
 }

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.",
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"
 }

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)"
 }

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given two buckets of different size, demonstrate how to measure an exact number of liters.",
   "source": "Water Pouring Problem",
   "source_url": "http://demonstrations.wolfram.com/WaterPouringProblem/"
 }

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -11,5 +11,6 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Create a sentence of the form \"One for X, one for me.\"",
   "source_url": "https://github.com/exercism/problem-specifications/issues/757"
 }

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Implement variable length quantity encoding and decoding.",
   "source": "A poor Splice developer having to implement MIDI encoding/decoding.",
   "source_url": "https://splice.com"
 }

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -11,5 +11,6 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour."
 }

--- a/exercises/practice/word-search/.meta/config.json
+++ b/exercises/practice/word-search/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Create a program to solve a word search puzzle."
 }

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
   "source": "Inspired by one of the generated questions in the Extreme Startup game.",
   "source_url": "https://github.com/rchatley/extreme_startup"
 }

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Score a single throw of dice in the game Yacht",
   "source": "James Kilfiger, using wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Yacht_(dice_game)"
 }

--- a/exercises/practice/zebra-puzzle/.meta/config.json
+++ b/exercises/practice/zebra-puzzle/.meta/config.json
@@ -11,6 +11,7 @@
       ".meta/Example.fs"
     ]
   },
+  "blurb": "Solve the zebra puzzle.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Zebra_Puzzle"
 }

--- a/exercises/practice/zipper/.meta/config.json
+++ b/exercises/practice/zipper/.meta/config.json
@@ -10,5 +10,6 @@
     "example": [
       ".meta/Example.fs"
     ]
-  }
+  },
+  "blurb": "Creating a zipper for a binary tree."
 }


### PR DESCRIPTION
Each Concept and Practice Exercise will have to define a _blurb_, which is a short description of the exercise.
The blurb will be displayed on a track's exercises page (e.g. https://exercism.lol/tracks/csharp/exercises).

For Practice Exercises that are based on an exercise defined in the problem-specification repo, the blurb must match the contents of the problem-specifications exercises, which is defined in its `metadata.yml` file. In this PR, we'll do an initial syncing of the blurb. The new [configlet](https://github.com/exercism/configlet) version will add support for doing this syncing automatically.

If the Practice Exercise was _not_ based on a problems-specifications exercise, we've used the blurb from its `.meta/metadata.yml` file as the blurb in the .meta/config.json file.

For Concept Exercises, we've added a placeholder blurb to the .meta/config.json file of each Concept Exercise.

**We've opened an issue for replacing the placeholder blurbs with sensible descriptions. Our recommendation is to merge this PR and then replace the placeholder blurbs in a follow-up PR. For forked exercises, it might be useful to check how other tracks have defined their blurb.**  

See the [Concept Exercise spec](https://github.com/exercism/docs/blob/main/anatomy/tracks/concept-exercises.md#file-metaconfigjson) and [Practice Exercise spec](https://github.com/exercism/docs/blob/main/anatomy/tracks/practice-exercises.md#file-metaconfigjson) for more information.

## Tracking

https://github.com/exercism/v3-launch/issues/21
